### PR TITLE
_ in validator function names are allowed in schema so should match w…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ const verify = (obj, sch, validators = {}) => {
       return validate(`${path}`, obj, lookups[sch * 1]);
 
     // if validator verify it now
-    if (sch.match(/^[a-zA-Z0-9]*$/)) {
+    if (sch.match(/^[a-zA-Z0-9_]*$/)) {
       if (obj === undefined || obj === null) {
         errors.push(`${path}: is required`);
         return false;


### PR DESCRIPTION
…hen checking custom validators

I think _ is common in function names and can even begin function names (like underscore). verify-json doesn't complain within the schema but would puke when being unable to match a custom validator function which has _ in it. This allows _.